### PR TITLE
fix bug where < should be <= in empirical cdf

### DIFF
--- a/src/aggregation/rra/utils.rs
+++ b/src/aggregation/rra/utils.rs
@@ -66,10 +66,9 @@ pub fn empirical_cdf(
     let size = null.len();
     let count = null
         .iter()
-        .filter(|x| **x < obs)
+        .filter(|x| **x <= obs)
         .count();
     (count + 1) as f64 / (size + 1) as f64
-
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Asymptomatic behavior was coming from mismatched `<` as opposed to `<=`. Once the p-values hit the block of `1.0`s it was set to whatever number of p-values were below the block. 