### PR TITLE
102 write testing for macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,15 @@ jobs:
         run: exit 0
 
   build:
-    runs-on: ubuntu-latest
+    name: Build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ "ubuntu-latest", "windows-latest", "macos-latest" ]
     steps:
-    - uses: actions/checkout@v3
-    - name: Build
-      run: cargo build --verbose
+      - uses: actions/checkout@v3
+      - name: Build
+        run: cargo build --verbose
 
   test:
     name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install nextest
         uses: taiki-e/install-action@nextest
       - name: Test
-        run: cargo nextest run
+        run: cargo nextest run --release
 
   coverage:
     name: Coverage

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ csv = "1.1.6"
 hashbrown = "0.12.3"
 intc = "0.1.4"
 ndarray = "0.15.6"
-ndarray-linalg = { version = "0.16.0", features = ["intel-mkl"] }
 ndarray-rand = "0.14.0"
 ndarray-stats = "0.5.0"
 noisy_float = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crispr_screen"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 description = "A fast and configurable differential expression analysis tool for CRISPR screens"
 license = "MIT"

--- a/src/aggregation/compute_aggregation.rs
+++ b/src/aggregation/compute_aggregation.rs
@@ -54,8 +54,7 @@ fn run_rra(
     correction: Procedure,
     logger: &Logger,
 ) -> InternalAggregationResult {
-    let (alpha_low, alpha_high) =
-        set_alpha_threshold(pvalue_low, pvalue_high, alpha, adjust_alpha);
+    let (alpha_low, alpha_high) = set_alpha_threshold(pvalue_low, pvalue_high, alpha, adjust_alpha);
     logger.report_rra_alpha(alpha_low, alpha_high);
 
     // Calculates the RRA score for the depleted pvalues

--- a/src/model/math.rs
+++ b/src/model/math.rs
@@ -1,8 +1,7 @@
 use ndarray::Array2;
 
-
 /// Determininant of a 2x2 matrix
-/// 
+///
 /// Calculated as a * d - b * c
 pub fn determinant(m: &Array2<f64>) -> f64 {
     assert_eq!(m.shape(), &[2, 2]);

--- a/src/model/math.rs
+++ b/src/model/math.rs
@@ -1,0 +1,45 @@
+use ndarray::Array2;
+
+
+/// Determininant of a 2x2 matrix
+/// 
+/// Calculated as a * d - b * c
+pub fn determinant(m: &Array2<f64>) -> f64 {
+    assert_eq!(m.shape(), &[2, 2]);
+    m[[0, 0]] * m[[1, 1]] - m[[0, 1]] * m[[1, 0]]
+}
+
+/// Inverse of a 2x2 matrix
+///
+/// Calculated as 1 / det * [[d, -b], [-c, a]]
+pub fn inverse(m: &Array2<f64>) -> Array2<f64> {
+    assert_eq!(m.shape(), &[2, 2]);
+    let det = determinant(m);
+    let mut inv = Array2::zeros((2, 2));
+    inv[[0, 0]] = m[[1, 1]] / det;
+    inv[[0, 1]] = -m[[0, 1]] / det;
+    inv[[1, 0]] = -m[[1, 0]] / det;
+    inv[[1, 1]] = m[[0, 0]] / det;
+    inv
+}
+
+#[cfg(test)]
+mod testing {
+
+    use super::*;
+    use ndarray::array;
+
+    #[test]
+    fn test_determinant() {
+        let m = array![[1., 2.], [3., 4.]];
+        assert_eq!(determinant(&m), -2.);
+    }
+
+    #[test]
+    fn test_inverse() {
+        let m = array![[1., 2.], [3., 4.]];
+        let inv = inverse(&m);
+        let expected = array![[-2., 1.], [1.5, -0.5]];
+        assert_eq!(inv, expected);
+    }
+}

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,18 +1,18 @@
 use clap::ValueEnum;
 
 mod logged_ols;
+mod math;
 mod model_mean_variance;
 mod ols;
 mod sqmean;
 mod wols;
-mod math;
 
 use logged_ols::LoggedOls;
+use math::inverse;
 pub use model_mean_variance::model_mean_variance;
 use ols::Ols;
 use sqmean::Sqmean;
 use wols::Wols;
-use math::inverse;
 
 #[derive(ValueEnum, Debug, Clone)]
 pub enum ModelChoice {

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -5,12 +5,14 @@ mod model_mean_variance;
 mod ols;
 mod sqmean;
 mod wols;
+mod math;
 
 use logged_ols::LoggedOls;
 pub use model_mean_variance::model_mean_variance;
 use ols::Ols;
 use sqmean::Sqmean;
 use wols::Wols;
+use math::inverse;
 
 #[derive(ValueEnum, Debug, Clone)]
 pub enum ModelChoice {

--- a/src/model/ols.rs
+++ b/src/model/ols.rs
@@ -1,5 +1,5 @@
 use ndarray::{Array1, Array2, Axis};
-use ndarray_linalg::solve::Inverse;
+use super::inverse;
 
 /// An implementation of [Ordinary Least Squares](https://en.wikipedia.org/wiki/Ordinary_least_squares#Matrix/vector_formulation) using a Matrix/Vector Formulation
 #[derive(Debug)]
@@ -29,7 +29,7 @@ impl Ols {
         // B = inv(XtX)XtY
         let xt = mat_x.t();
         let xtx = xt.dot(&mat_x);
-        let inv_xtx = Inverse::inv(&xtx).expect("Unable to computer inverse matrix in OLS");
+        let inv_xtx = inverse(&xtx);
 
         // drop an axis from the solution for a 1D vector
         let solution = inv_xtx.dot(&xt).dot(&mat_y).remove_axis(Axis(1));

--- a/src/model/ols.rs
+++ b/src/model/ols.rs
@@ -1,5 +1,5 @@
-use ndarray::{Array1, Array2, Axis};
 use super::inverse;
+use ndarray::{Array1, Array2, Axis};
 
 /// An implementation of [Ordinary Least Squares](https://en.wikipedia.org/wiki/Ordinary_least_squares#Matrix/vector_formulation) using a Matrix/Vector Formulation
 #[derive(Debug)]

--- a/src/model/wols.rs
+++ b/src/model/wols.rs
@@ -1,5 +1,5 @@
 use ndarray::{Array1, Array2, Axis};
-use ndarray_linalg::solve::Inverse;
+use super::inverse;
 
 /// An implementation of [Weighted Least Squares](https://en.wikipedia.org/wiki/Weighted_least_squares) using a Matrix/Vector Formulation
 #[derive(Debug)]
@@ -38,7 +38,7 @@ impl Wols {
         let xt = mat_x.t();
         let xtw = xt.dot(&mat_w);
         let xtwx = xtw.dot(&mat_x);
-        let inv_xtwx = Inverse::inv(&xtwx).expect("Unable to computer inverse matrix in OLS");
+        let inv_xtwx = inverse(&xtwx);
 
         // drop an axis from the solution for a 1D vector
         let solution = inv_xtwx.dot(&xtw).dot(&mat_y).remove_axis(Axis(1));

--- a/src/model/wols.rs
+++ b/src/model/wols.rs
@@ -1,5 +1,5 @@
-use ndarray::{Array1, Array2, Axis};
 use super::inverse;
+use ndarray::{Array1, Array2, Axis};
 
 /// An implementation of [Weighted Least Squares](https://en.wikipedia.org/wiki/Weighted_least_squares) using a Matrix/Vector Formulation
 #[derive(Debug)]


### PR DESCRIPTION
removed ndarray-linalg dependency because it was having distribution issues to mac and windows. 

since I was only using it for inverse matrix calculations and the maximum matrix size I expect is 2x2 - it was simpler to just write this in explicitly instead of calling this dependency. 